### PR TITLE
Add return code for target group healthcheck

### DIFF
--- a/nginx/redash.conf
+++ b/nginx/redash.conf
@@ -15,7 +15,7 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
-
+    return 200;
     proxy_pass       http://redash;
   }
 }


### PR DESCRIPTION
Add return code 200 for target group healthchecks to succeed, as they were failing when getting code 302 redirect.